### PR TITLE
support de precision et scale dans le datatype java.math.BigDecimal

### DIFF
--- a/mda-generator/src/main/java/mda/generator/beans/UmlDomain.java
+++ b/mda-generator/src/main/java/mda/generator/beans/UmlDomain.java
@@ -14,6 +14,7 @@ public class UmlDomain {
 	private String typeName;
 	private String maxLength;
 	private String precision;
+	private String scale;
 	
 	/**
 	 * @return the name
@@ -67,10 +68,23 @@ public class UmlDomain {
 	public void setPrecision(String precision) {
 		this.precision = precision;
 	}
+	/**
+	 * @return the scale
+	 */
+	public String getScale() {
+		return scale;
+	}
+	/**
+	 * @param scale the scale to set
+	 */
+	public void setScale(final String scale) {
+		this.scale = scale;
+	}
 	public String toString() {
 		return "\n\t" + name + "(" + typeName + ")" 
 			+ (maxLength != null && !maxLength.equals("0")?" maxLength="+maxLength:""
-			+ (precision != null && !precision.equals("0")?" precision="+precision:"")
+			+ (precision != null && !precision.equals("0")?" precision="+precision:""
+			+ (scale != null && !scale.equals("0") ? " scale=" + scale : ""))
 		);
 	}
 }

--- a/mda-generator/src/main/java/mda/generator/converters/type/DomainToPostgresConverter.java
+++ b/mda-generator/src/main/java/mda/generator/converters/type/DomainToPostgresConverter.java
@@ -2,6 +2,7 @@ package mda.generator.converters.type;
 
 
 import mda.generator.beans.UmlDomain;
+import mda.generator.exceptions.MdaGeneratorException;
 
 
 /**
@@ -53,6 +54,43 @@ public class DomainToPostgresConverter extends AbstractDomainToJavaConverter {
 				break;
 			case "Double":
 				dbType = "DOUBLE PRECISION";
+				break;
+			case "java.math.BigDecimal":
+				if(domain.getScale() == null && domain.getPrecision() == null) {
+					dbType = "NUMERIC";
+				} else if(domain.getScale() == null) {
+					// Nombre total de chiffres (= precision)
+					final int precision = Integer.parseInt(domain.getPrecision());
+
+					if(precision <= 0) {
+						throw new MdaGeneratorException("Impossible de convertir le domaine " + domain.getName()
+							+ " avec une precision inférieure au égale à 0.");
+					}
+					dbType = "NUMERIC(" + precision + ')';
+				} else {
+					if(domain.getPrecision() == null) {
+						throw new MdaGeneratorException("Impossible de convertir le domaine " + domain.getName()
+							+ " avec scale non null et precision null");
+					}
+					// Nombre de chiffres après la virgule (=scale)
+					int scale = Integer.parseInt(domain.getScale());
+					// Nombre total de chiffres (= precision)
+					final int precision = Integer.parseInt(domain.getPrecision());
+
+					if(precision <= 0) {
+						throw new MdaGeneratorException("Impossible de convertir le domaine " + domain.getName()
+							+ " avec une precision inférieure au égale à 0.");
+					}
+					if(scale > precision) {
+						throw new MdaGeneratorException("Impossible de convertir le domaine " + domain.getName()
+							+ " avec une scale > precision");
+					}
+					if(scale < 0) {
+						scale = 0;
+					}
+
+					dbType = "NUMERIC(" + precision + "," + scale + ")";
+				}
 				break;
 			case "Byte[]":
 			case "java.sql.Blob":

--- a/mda-generator/src/main/java/mda/generator/readers/xmi/XmiReader.java
+++ b/mda-generator/src/main/java/mda/generator/readers/xmi/XmiReader.java
@@ -102,11 +102,15 @@ public class XmiReader implements ModelFileReaderInterface {
 					}
 					
 					if("Java".equals(columnNameValue.get("ProductName"))){
+						// Dans EA, menu Code, Configure, Product Name Java
+						// puis menu Configure, Transfer, Export Reference Data : Model Data Types - Code and DDL
+						// -> /model/example_metadata.xml pour la génération
 						UmlDomain umlDomain = new UmlDomain();
 						umlDomain.setName(columnNameValue.get("DataType")); 
 						umlDomain.setTypeName(columnNameValue.get("GenericType"));
 						umlDomain.setMaxLength(columnNameValue.get("MaxLen"));
-						umlDomain.setPrecision(columnNameValue.get("MaxPrec"));
+						umlDomain.setPrecision(columnNameValue.get("DefaultPrec"));
+						umlDomain.setScale(columnNameValue.get("DefaultScale"));
 						domainsMap.put(umlDomain.getName(), umlDomain);
 					}
 				}


### PR DESCRIPTION
NB : dans le fichier xml des datatypes, on utilise après cette PR l'attribut DefaultPrec (et DefaultScale) des datatypes plutôt que l'attribut MaxPrec. C'est plus cohérent avec l'ihm EA.