### PR TITLE
crlf on windows

### DIFF
--- a/mda-generator/src/main/java/mda/generator/writers/VelocityUtils.java
+++ b/mda-generator/src/main/java/mda/generator/writers/VelocityUtils.java
@@ -44,7 +44,7 @@ public class VelocityUtils {
 				// We keep user edited content
 				if(keepContent) {
 					if(lineAdded) {
-						contentToKeep.append("\n");
+						contentToKeep.append(System.lineSeparator());
 					}else {
 						lineAdded=true;
 					}

--- a/mda-generator/src/main/resources/templates/entity.vm
+++ b/mda-generator/src/main/resources/templates/entity.vm
@@ -1,5 +1,4 @@
-package $javaClass.getPackageName();
-
+package $javaClass.getPackageName();
 ## IMPORTS
 import java.io.Serializable;
 #foreach( $import in $javaClass.getImportsList() )
@@ -17,7 +16,7 @@ import $import;
 ## ANNOTATIONS
 #foreach( $annotation in $javaClass.getAnnotationsList() )
 $annotation.getDisplay("")
-#end 
+#end
 ## USER DEFINED ANNOTATIONS
 #if($javaClass.getUserDefinedAnnotations())
 #foreach( $annotation in $javaClass.getUserDefinedAnnotations() )
@@ -25,40 +24,40 @@ $annotation
 #end
 #end
 ## CLASS DECLARATION
-$javaClass.getVisibilite().toString() class $javaClass.getName() implements Serializable{
+$javaClass.getVisibilite().toString() class $javaClass.getName() implements Serializable {
 	/** Serial ID */
 	private static final long serialVersionUID = 1L;
 
 ## COMPOSITE KEY
-#if($javaClass.getPkClass())	
-	@EmbeddedId 
+#if($javaClass.getPkClass())
+	@EmbeddedId
 	$javaClass.getPkField().getJavaType() $javaClass.getPkField().getName();
 #end
 ## ATTRIBUTES
 #foreach( $attribute in $javaClass.getAttributesList() )
 	$attribute.getVisibility().toString() $attribute.getJavaType() $attribute.getName()#if($attribute.getDefaultValue()) = $attribute.getDefaultValue()#end;
-#end 
+#end
 
 ## METHODS
 #foreach( $method in $javaClass.getMethodsList() )
 ## METHOD COMMENTS
-    /**
+	/**
 #foreach( $comment in $method.getCommentsList() )
-     * $comment
+	 * $comment
 #end
-     */
+	 */
 ## METHOD ANNOTATION
 #foreach( $annotation in $method.getAnnotationsList() )
-$annotation.getDisplay("    ")
-#end	 
+$annotation.getDisplay("	")
+#end
 ## METHOD DECLARATION
 	$method.getVisibility().toString() $method.getReturnType() $method.getName()($method.getDisplayArgs()){
 ## METHOD BODY
 #foreach($contentLine in $method.getContentLines())
 		$contentLine;
-#end	 
-    }  
-#end 
+#end
+	}
+#end
 
 ## hashcode and equals
 	@Override
@@ -103,8 +102,6 @@ $annotation.getDisplay("    ")
 #end		;
 	}
 
-
-
-## END OF CLASS
+## END OF CLASS
 $end_of_generated
 #if ( $keep_content )$content_to_keep#else}#end


### PR DESCRIPTION
En général, les fichiers sources ont des retours chariots CRLF (\r\n) sur windows et pas seulement LF (\n).
Avec git, la conversion CRLF<->LF est souvent automatisée, par exemple avec le fichier .gitattributes à la racine du repo comme ceci :
```
# Automatically normalize line endings for all text-based files
# http://git-scm.com/docs/gitattributes#_end_of_line_conversion
* text=auto
*.sh		text eol=lf
```

Donc autant générer les fichiers de manière à ne pas avoir de différences à chaque génération avec les mêmes fichiers récupérés du repo, càd avec CRLF sur windows.